### PR TITLE
Use -P on Linux so there isn't line wrapping.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
     , reCaptureCells = /^([^\s]+\s?[^\s]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+[^/]*(.*?)\s*$/
     , cmdMap = {
           "Darwin": "df -b"
-        , "Linux": "df -B 512"
+        , "Linux": "df -PB 512"
       }
     , reMap = {
           "Darwin": reCaptureCells
@@ -68,7 +68,7 @@
       cb(null, infos);
     }
 
-    exec('df', formatDf);
+    exec(cmdDf, formatDf);
   }
 
   function main () {


### PR DESCRIPTION
Long filesystem names, by default will get their own line.  This means they wont match the regex and then will be skipped in the program output.

Example (formatting is bad but should give you the general idea):
Filesystem         512B-blocks      Used Available Use% Mounted on
/dev/mapper/VolGroup00-LogVol00
                     125661064  64176336  55101528  54% /
tmpfs                 15511968         8  15511960   1% /dev/shm
/dev/vda1               198300     71880    116180  39% /boot
nfs_mount.some_company.com:/home
                     542799040 357911296 156883648  70% /home

Also use cmdDf instead of just 'df'.
