### PR TITLE
updated linux df comand, use cmdDf, new regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@
   // map auto_home          0         0         0   100%    /home
   var exec = require('child_process').exec
     , os = require('os')
-    , reCaptureCells = /^([^\s]+\s?[^\s]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+[^/]*(.*?)\s*$/
+    , reCaptureCells = /^([^\s]+\s?[^\s]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+[^/]*(.*?)\s+(.*?)\s*$/
     , cmdMap = {
           "Darwin": "df -b"
-        , "Linux": "df -B 512"
+        , "Linux": "df -B 512 --output=source,size,used,avail,pcent,target,fstype"
       }
     , reMap = {
           "Darwin": reCaptureCells
@@ -46,6 +46,7 @@
           , available: parseInt(cells[4], 10)
           , percent: parseInt(cells[5], 10)
           , mountpoint: cells[6]
+          , type: cells[7]
         });
       }
 
@@ -68,7 +69,7 @@
       cb(null, infos);
     }
 
-    exec('df', formatDf);
+    exec(cmdDf, formatDf);
   }
 
   function main () {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@
   // map auto_home          0         0         0   100%    /home
   var exec = require('child_process').exec
     , os = require('os')
-    , reCaptureCells = /^([^\s]+\s?[^\s]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+[^/]*(.*?)\s+(.*?)\s*$/
+    , reCaptureCellsDarwin = /^([^\s]+\s?[^\s]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+[^/]*(.*?)\s*$/;
+    , reCaptureCellsLinux = /^([^\s]+\s?[^\s]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+[^/]*(.*?)\s+(.*?)\s*$/
     , cmdMap = {
           "Darwin": "df -b"
         , "Linux": "df -B 512 --output=source,size,used,avail,pcent,target,fstype"
@@ -39,15 +40,26 @@
         // FYI
         // It seems that RegExp Match isn't a true array
         // popping it deos weird things
-        infos.push({
-            filesystem: cells[1]
-          , blocks: parseInt(cells[2], 10)
-          , used: parseInt(cells[3], 10)
-          , available: parseInt(cells[4], 10)
-          , percent: parseInt(cells[5], 10)
-          , mountpoint: cells[6]
-          , type: cells[7]
-        });
+        if(os.type() == "Darwin") {
+          infos.push({
+              filesystem: cells[1]
+            , blocks: parseInt(cells[2], 10)
+            , used: parseInt(cells[3], 10)
+            , available: parseInt(cells[4], 10)
+            , percent: parseInt(cells[5], 10)
+            , mountpoint: cells[6]
+          });
+        } else {
+          infos.push({
+              filesystem: cells[1]
+            , blocks: parseInt(cells[2], 10)
+            , used: parseInt(cells[3], 10)
+            , available: parseInt(cells[4], 10)
+            , percent: parseInt(cells[5], 10)
+            , mountpoint: cells[6]
+            , type: cells[7]
+          });
+        }
       }
 
       if (err) {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
   // map auto_home          0         0         0   100%    /home
   var exec = require('child_process').exec
     , os = require('os')
-    , reCaptureCellsDarwin = /^([^\s]+\s?[^\s]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+[^/]*(.*?)\s*$/;
+    , reCaptureCellsDarwin = /^([^\s]+\s?[^\s]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+[^/]*(.*?)\s*$/
     , reCaptureCellsLinux = /^([^\s]+\s?[^\s]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+[^/]*(.*?)\s+(.*?)\s*$/
     , cmdMap = {
           "Darwin": "df -b"

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@
         , "Linux": "df -B 512 --output=source,size,used,avail,pcent,target,fstype"
       }
     , reMap = {
-          "Darwin": reCaptureCells
-        , "Linux": reCaptureCells
+          "Darwin": reCaptureCellsDarwin
+        , "Linux": reCaptureCellsLinux
       }
     , cmdDf = cmdMap[os.type()]
     , reDf = reMap[os.type()]


### PR DESCRIPTION
I changed the df comand to get addtional information. With the output param from df you can add additional informations. (found this information in linux comand: "info coreutils 'df invocation' ") Its nice to know the filesystem type too. Because of that i changed the regex and added "type" to the "infos" object.
Also i fixed the use of the cmdDf variable as requested before.
